### PR TITLE
fix(ci): least-privilege permissions on CI workflow (CodeQL)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds top-level `permissions: { contents: read }` to `.github/workflows/ci.yml`, resolving the `actions/missing-workflow-permissions` CodeQL alert. The workflow only builds/tests (no writes), so read-only is least-privilege and removes the default broad `GITHUB_TOKEN` scope. Part of the org-wide 2026-06-17 security sweep.